### PR TITLE
Initiate workflow only on source repo

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ permissions:
   id-token: write # needed for signing the images with GitHub OIDC Token
 jobs:
   build:
+    if: github.repository == 'arina999999997/elichika'
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU


### PR DESCRIPTION
Restricts docker image workflow to run only on the source repo.

Tested on my fork, no actions triggered for new changes: https://github.com/yunimoo/elichika/actions/runs/9822862619/job/27120051687